### PR TITLE
Delete deprecated CoroutineCallAdapterFactory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,7 @@ dependencies {
 
     implementation 'com.squareup.retrofit2:retrofit:2.6.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.6.0'
-    implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.14.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.0.1'
 
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/app/src/main/java/com/teamtwo/apilol/model/LOLService.kt
+++ b/app/src/main/java/com/teamtwo/apilol/model/LOLService.kt
@@ -5,10 +5,10 @@ interface LOLService {
     /* Architect Codders Example
 
     @GET("discover/movie?sort_by=popularity.desc")
-    fun listPopularMoviesAsync(
+    suspend fun listPopularMoviesAsync(
         @Query("api_key") apiKey: String,
         @Query("region") region: String
-    ): Deferred<MovieDbResult>
+    ): MovieDbResult
 
     */
 

--- a/app/src/main/java/com/teamtwo/apilol/model/LOLServiceManager.kt
+++ b/app/src/main/java/com/teamtwo/apilol/model/LOLServiceManager.kt
@@ -15,7 +15,6 @@ class LOLServiceManager {
     val service: LOLService = Retrofit.Builder()
         .baseUrl("http://ddragon.leagueoflegends.com/cdn/9.23.1/")
         .client(okHttpClient)
-        .addCallAdapterFactory(CoroutineCallAdapterFactory())
         .addConverterFactory(GsonConverterFactory.create())
         .build().run {
             create<LOLService>(LOLService::class.java)

--- a/app/src/main/java/com/teamtwo/apilol/model/LOLServiceManager.kt
+++ b/app/src/main/java/com/teamtwo/apilol/model/LOLServiceManager.kt
@@ -1,6 +1,5 @@
 package com.teamtwo.apilol.model
 
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit


### PR DESCRIPTION
- Deleted coroutines-adapter from gradle.
- Deleted CoroutineCallAdapterFactory from Retrofit interface.
- Updated LolService example

fix #4 